### PR TITLE
add `<area>` to list of interesttarget supporting elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ touched, or enacted via keypress - dispatch an `InvokeEvent` on the element
 referenced by `invokertarget`, with some default behaviours.
 
 In addition, adding an `interesttarget` attribute to `<button>`, `<a>`,
-`<input>` elements would allow disclosure of high fidelity tooltips in a more
+`<area>`, `<input>` elements would allow disclosure of high fidelity tooltips in a more
 accessible and declaritive way. Elements with `interesttarget` will - when
 hovered, long pressed, or focussed - dispatch an `InterestEvent` on the element
 referenced by `interesttarget`, with some default behaviours.
@@ -86,7 +86,7 @@ the balance.
 In the style of `popovertarget`, this document proposes we add `invokertarget`,
 and `invokeraction` as available attributes to `<button>`,
 `<input type="button">` and `<input type="reset">` elements, as well as an
-`interesttarget` attribute to `<button>`, `<a>`, and `<input>` elements.
+`interesttarget` attribute to `<button>`, `<a>`, `<area>` and `<input>` elements.
 
 ```webidl
 interface mixin InvokerElement {

--- a/invoker.d.ts
+++ b/invoker.d.ts
@@ -19,6 +19,7 @@ declare global {
   interface HTMLButtonElement extends InvokerMixin, InterestMixin {}
   interface HTMLInputElement extends InvokerMixin, InterestMixin {}
   interface HTMLAnchorElement extends InterestMixin {}
+  interface HTMLAreaElement extends InterestMixin {}
   interface HTMLSummaryElement extends InterestMixin {}
   /* eslint-enable @typescript-eslint/no-empty-interface */
   interface Window {


### PR DESCRIPTION
Given `<area>` is effectively a special form of `<a>` it makes sense to include support for the interest system with it.