### PR TITLE
implement `<input>` defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,7 +343,7 @@ table represents how invocations on specific element types are handled. Note
 that this list is ordered and higher rules take precedence:
 
 | Invokee Element       | `action` hint   | Behaviour                                                                            |
-| :-------------------- | :-------------- | :----------------------------------------------------------------------------------- |
+|:----------------------| :-------------- |:-------------------------------------------------------------------------------------|
 | `<* popover>`         | `'auto'`        | Call `.togglePopover()` on the invokee                                               |
 | `<* popover>`         | `'hidePopover'` | Call `.hidePopover()` on the invokee                                                 |
 | `<* popover>`         | `'showPopover'` | Call `.showPopover()` on the invokee                                                 |
@@ -353,7 +353,7 @@ that this list is ordered and higher rules take precedence:
 | `<details>`           | `'auto'`        | If the `<details>` is `open`, then close it, otherwise open it                       |
 | `<details>`           | `'open'`        | If the `<details>` is not `open`, then open it                                       |
 | `<details>`           | `'close'`       | If the `<details>` is `open`, then close it                                          |
-| `<input type="file">` | `'auto'`        | Open the OS file picker, in other words act as if the input itself had been clicked  |
+| `<input>`             | `'auto'`        | Call `.showPicker()` on the invokee                                                  |
 | `<video>`             | `'auto'`        | Toggle the `.playing` value                                                          |
 | `<video>`             | `'pause'`       | If `.playing` is `true`, set it to `false`                                           |
 | `<video>`             | `'play'`        | If `.playing` is `false`, set it to `true`                                           |

--- a/example.html
+++ b/example.html
@@ -26,6 +26,16 @@
       future all of the below will work without any JavaScript!
     </p>
     <hr />
+    <button invokertarget="my-file-input">
+      This will open the file picker
+    </button>
+    <input type="file" id="my-file-input" />
+    <hr />
+    <button invokertarget="my-date-input" invokeraction="showPicker">
+      This should open the date picker
+    </button>
+    <input type="date" id="my-date-input" />
+    <hr />
 
     <button invokertarget="my-details" interesttarget="button-explainer">
       This will open the details

--- a/invoker.js
+++ b/invoker.js
@@ -211,6 +211,13 @@ function handleDefaultInvoke(invoker) {
   if (event.defaultPrevented) return;
 
   switch (invokee.localName) {
+    case "input": {
+      if (["auto", "showpicker"].includes(event.action)) {
+        event.target.showPicker();
+      }
+      break;
+    }
+
     case "details": {
       switch (event.action) {
         case "auto": {

--- a/invoker.js
+++ b/invoker.js
@@ -212,7 +212,7 @@ function handleDefaultInvoke(invoker) {
 
   switch (invokee.localName) {
     case "input": {
-      if (["auto", "showpicker"].includes(event.action)) {
+      if (event.action === "auto" || event.action === "showpicker") {
         event.target.showPicker();
       }
       break;


### PR DESCRIPTION
Currently  the defaults table includes <input type="file"> (but isn't implemented). It makes sense to open this up to all input elements with a showPicker implemented for them. This PR adds the handling for this.

Should be noted Safari doesn't implement `showPicker` for date inputs (https://bugs.webkit.org/show_bug.cgi?id=257308) so that example won't work in Safari.

Actions:

- `auto` and `showpicker` calls the `showPicker` method on the input.