### PR TITLE
readme: use camel case in react onClick example

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ behaviour. These patterns reduce developer experience and introduce more
 boilerplate and friction, while remediating security and maintainability
 concerns. Some frameworks attempt to reintroduce the developer experience of
 inline handlers by introducing new JavaScript or HTML shorthands, such as
-React's `onclick={...}`, Vue's `@click=".."` or HTMX's `hx-trigger="click"`.
+React's `onClick={...}`, Vue's `@click=".."` or HTMX's `hx-trigger="click"`.
 
 There has also been a rise in the desire to customise controls for components.
 Many sites, for example, introduce custom controls for File Uploads or dropdown


### PR DESCRIPTION
I feel like not fixing this may distract from the actual idea/point of the repository