### PR TITLE
Fix `'togglePopvoer'` typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,7 +363,7 @@ that this list is ordered and higher rules take precedence:
 | Invokee Element | `action` hint         | Behaviour                                                                            |
 | :-------------- | :-------------------- | :----------------------------------------------------------------------------------- |
 | `<* popover>`   | `'auto'`              | Call `.togglePopover()` on the invokee                                               |
-| `<* popover>`   | `'togglePopvoer'`     | Call `.togglePopover()` on the invokee                                               |
+| `<* popover>`   | `'togglePopover'`     | Call `.togglePopover()` on the invokee                                               |
 | `<* popover>`   | `'hidePopover'`       | Call `.hidePopover()` on the invokee                                                 |
 | `<* popover>`   | `'showPopover'`       | Call `.showPopover()` on the invokee                                                 |
 | `<dialog>`      | `'auto'`              | If the `<dialog>` is not `open`, call `showModal()`, otherwise cancel the dialog     |


### PR DESCRIPTION
Hi @keithamus , thanks for this proposal! Anything that can make HTML on its own more capable is great!

Quick PR to fix the typo `'togglePopvoer'`