### PR TITLE
Call `super(…)` from `InvokeEvent` constructor

### DIFF
--- a/invoker.js
+++ b/invoker.js
@@ -112,7 +112,8 @@ export function apply() {
   enumerate(CommandEvent.prototype, "command");
 
   class InvokeEvent extends Event {
-    constructor() {
+    constructor(type, invokeEventInit = {}) {
+      super(type, invokeEventInit);
       throw new Error(
         "InvokeEvent has been deprecated, it has been renamed to `CommandEvent`",
       );


### PR DESCRIPTION
We've received an upstream issue for `@tailwindplus/element` that the project won't compile with [Google Closure Compiler](https://github.com/google/closure-compiler). Upon further investigating, the issue seems that the compiler requires subclasses of `Event` to always call `super(…)`:

<img width="2672" height="1521" alt="Screenshot 2025-08-05 at 10 43 35" src="https://github.com/user-attachments/assets/4638b452-2a7b-45b7-8e44-3da8cdc70ed3" />

This PR adds a `super(…)` call similar to the other Event sub type to fix this issue:

<img width="2672" height="1521" alt="Screenshot 2025-08-05 at 10 43 43" src="https://github.com/user-attachments/assets/bb0042ad-8a3e-464b-9a9b-30f360f4775d" />

I know this is not required for the runtime since the constructor always throws, but I'm hoping we can still resolve this upstream 🙂 