### PR TITLE
Fix nested commands

### DIFF
--- a/invoker.js
+++ b/invoker.js
@@ -298,7 +298,13 @@ export function apply() {
   });
   applyOnCommandHandler(document.querySelectorAll("[oncommand]"));
 
+  const processedEvents = new WeakSet();
+
   function handleInvokerActivation(event) {
+    if (processedEvents.has(event)) return;
+    
+    processedEvents.add(event);
+
     if (event.defaultPrevented) return;
     if (event.type !== "click") return;
     const oldInvoker = event.target.closest(
@@ -406,8 +412,7 @@ export function apply() {
   applyInvokerMixin(HTMLButtonElement);
 
   observeShadowRoots(HTMLElement, (shadow) => {
-    // Make sure to not re-attach listeners here, because click events are composable and already pierce
-    // the shadow dom, so the click listener on the document is enough
+    setupInvokeListeners(shadow);
     oncommandObserver.observe(shadow, { attributeFilter: ["oncommand"] });
     applyOnCommandHandler(shadow.querySelectorAll("[oncommand]"));
   });


### PR DESCRIPTION
Hi !

This PR fixes an issue where the command event would be sent multiple times if the command would be nested (which does not happen with the native implementation).

For instance, considering this HTML:

```html
<div>
  <button commandfor="one" command="--toggle">Open</button>

  <x-disclosure id="one">
    <button commandfor="two" command="--toggle">Open</button>
    
    <x-disclosure id="two">

    </x-disclosure>
  <x-disclosure>
</div>
```

Before this fix, clicking on the commandfor="two" button would dispatch two `command` events on the "two" web component.

Thanks.