### PR TITLE
Handle composed click events properly

### DIFF
--- a/invoker.js
+++ b/invoker.js
@@ -240,9 +240,7 @@ export function apply() {
 
     if (event.defaultPrevented) return;
     if (event.type !== "click") return;
-    const source = event.target.shadowRoot
-      ? event.composedPath().find((el) => el.matches("button[commandfor], button[command]"))
-      : event.target.closest("button[commandfor], button[command]");
+    const source = event.composedPath().find((el) => el.matches("button[commandfor], button[command]"));
     if (!source) return;
 
     if (source.form && source.getAttribute("type") !== "button") {


### PR DESCRIPTION
This adds a fix where the `click` event happened in the shadowroot of a custom element. The polyfill get's the click event on the custom element itself. This checks if `event.target` has a shadowRoot, it doesn't use `.closest()`, but instead it looks for the originating `<button>` using `event.composedPath()`.